### PR TITLE
Add scaffolding and setup.py file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Charm specific
+build/
+*.charm
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Sphinx documentation
+docs/_build/
+
+# PEP 582
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mkdocs documentation
+/site

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# hpct-ops
+
+> This repository is currently a work-in-progress.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"
+
+# Formatting tools configuration
+[tool.black]
+line-length = 99
+target-version = ["py38"]
+
+[tool.isort]
+line_length = 99
+profile = "black"
+
+# Linting tools configuration
+[tool.flake8]
+max-line-length = 99
+max-doc-length = 99
+max-complexity = 10
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "__init__.py"]
+select = ["E", "W", "F", "C", "N", "R", "D", "H"]
+# Ignore W503, E501 because using black creates errors with this
+# Ignore D107 Missing docstring in __init__
+ignore = ["W503", "E501", "D107"]
+# D100, D101, D102, D103: Ignore missing docstrings in tests
+per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
+docstring-convention = "google"
+# Check for properly formatted copyright header in each file
+copyright-check = "True"
+copyright-author = "Canonical Ltd."
+copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ops==1.5.2
+setuptools==59.6.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from setuptools import setup, find_packages
+
+
+setup(
+    name="hpctops",
+    version="0.1.0",
+    description="Operator base classes for the HPC team at Canonical",
+    license="Apache-2.0",
+    packages=find_packages(where="lib", include=["hpctops*"]),
+    package_dir={"": "lib"},
+    install_requires=["ops"],
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,52 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+[tox]
+skipsdist=True
+skip_missing_interpreters = True
+envlist = lint
+
+[vars]
+src_path = {toxinidir}/lib/
+tst_path = {toxinidir}/tests/
+all_path = {[vars]src_path} {[vars]tst_path} 
+
+[testenv]
+setenv =
+  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+  PYTHONBREAKPOINT=ipdb.set_trace
+  PY_COLORS=1
+passenv =
+  PYTHONPATH
+  CHARM_BUILD_DIR
+  MODEL_SETTINGS
+
+[testenv:fmt]
+description = Apply coding style standards to code
+deps =
+  black
+  isort
+commands =
+  isort {[vars]all_path}
+  black {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+  black
+  flake8
+  flake8-docstrings
+  flake8-copyright
+  flake8-builtins
+  pyproject-flake8
+  pep8-naming
+  isort
+  codespell
+commands =
+  codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
+    --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
+  # pflake8 wrapper supports config from pyproject.toml
+  pflake8 {[vars]all_path}
+  isort --check-only --diff {[vars]all_path}
+  black --check --diff {[vars]all_path}


### PR DESCRIPTION
This pull request aims to add some new files and functionality to the project:

* `README.md` - Template README for feature documentation such as where to get documentation.
* `.gitignore` - To prevent any pycache, build artifacts, etc. from working their way into commits.
* `pyproject.toml` and `tox.ini` - Tox environments for formatting and linting library code. Can also expand out to publishing, doc serving, and functional/unit/smoke tests.
* `requirements.txt` - So others can replicate the development environment.
* `setup.py` - Allows us to pull the package from GitHub and/or upload to PyPI at a later date.